### PR TITLE
feat: Disable relation integer casting to allow UUIDs with custom Models

### DIFF
--- a/src/Models/Feature.php
+++ b/src/Models/Feature.php
@@ -21,7 +21,6 @@ use Spatie\Sluggable\SlugOptions;
  * Laravelcm\Subscriptions\Models\PlanFeature.
  *
  * @property int $id
- * @property int $plan_id
  * @property string $slug
  * @property array $title
  * @property array $description
@@ -71,7 +70,6 @@ class Feature extends Model implements Sortable
     ];
 
     protected $casts = [
-        'plan_id' => 'integer',
         'slug' => 'string',
         'value' => 'string',
         'resettable_period' => 'integer',

--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -23,9 +23,7 @@ use Spatie\Sluggable\SlugOptions;
  * Laravelcm\Subscriptions\Models\Subscription.
  *
  * @property int $id
- * @property int $subscriber_id
  * @property string $subscriber_type
- * @property int $plan_id
  * @property string $slug
  * @property array $title
  * @property array $description
@@ -86,9 +84,7 @@ class Subscription extends Model
     ];
 
     protected $casts = [
-        'subscriber_id' => 'integer',
         'subscriber_type' => 'string',
-        'plan_id' => 'integer',
         'slug' => 'string',
         'trial_ends_at' => 'datetime',
         'starts_at' => 'datetime',

--- a/src/Models/SubscriptionUsage.php
+++ b/src/Models/SubscriptionUsage.php
@@ -15,8 +15,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
  * Laravelcm\Subscriptions\Models\SubscriptionUsage.
  *
  * @property int $id
- * @property int $subscription_id
- * @property int $feature_id
  * @property int $used
  * @property Carbon|null $valid_until
  * @property Carbon|null $created_at
@@ -49,8 +47,6 @@ class SubscriptionUsage extends Model
     ];
 
     protected $casts = [
-        'subscription_id' => 'integer',
-        'feature_id' => 'integer',
         'used' => 'integer',
         'valid_until' => 'datetime',
         'deleted_at' => 'datetime',


### PR DESCRIPTION
It is initially unclear that the problem stems from Models using HasUuids still casting relation IDs to integers with $casts. This relation_id casting is unnecessary, so it would be better to remove it entirely