### PR TITLE
fix: fix query to calculate quota used by feature

### DIFF
--- a/src/Models/SubscriptionUsage.php
+++ b/src/Models/SubscriptionUsage.php
@@ -74,7 +74,7 @@ class SubscriptionUsage extends Model
     public function scopeByFeatureSlug(Builder $builder, string $featureSlug): Builder
     {
         $model = config('laravel-subscriptions.models.feature', Feature::class);
-        $feature = tap(new $model())->where('slug', $featureSlug)->first();
+        $feature = (new $model())->where('slug', $featureSlug)->first();
 
         return $builder->where('feature_id', $feature ? $feature->getKey() : null);
     }


### PR DESCRIPTION
Technically the model class will never not have a type, so we can remove the tap here.

The tap was resetting the query, causing it to lose the "where slug = ?" and return the wrong feature.