### PR TITLE
Multiple features can now be used with the same slug

### DIFF
--- a/database/migrations/update_unique_keys_on_features_table.php
+++ b/database/migrations/update_unique_keys_on_features_table.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table(config('laravel-subscriptions.tables.features'), function (Blueprint $table): void {
+            $table->dropUnique(config('laravel-subscriptions.tables.features') . '_slug_unique');
+            $table->unique(['plan_id', 'slug']);
+        });
+    }
+};

--- a/src/SubscriptionServiceProvider.php
+++ b/src/SubscriptionServiceProvider.php
@@ -20,6 +20,7 @@ final class SubscriptionServiceProvider extends PackageServiceProvider
                 'create_plan_subscriptions_table',
                 'create_plan_subscription_usage_table',
                 'remove_unique_slug_on_subscriptions_table',
+                'update_unique_keys_on_features_table',
             ])
             ->hasInstallCommand(function (InstallCommand $command): void {
                 $command


### PR DESCRIPTION
Previously you could only use one feature with the same slug since when creating another feature in another plan a prefix was added

Plan 1
feature-1
Plan2
feature-2

now multiple can be used for different plans 

Plan 1
feature
Plan 2
feature

But a plan can only have one feature with the same slug