### PR TITLE
Fixed duplicate feature slugs.

### DIFF
--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -338,7 +338,7 @@ class Subscription extends Model
 
     public function reduceFeatureUsage(string $featureSlug, int $uses = 1): ?SubscriptionUsage
     {
-        $usage = $this->usage()->byFeatureSlug($featureSlug)->first();
+        $usage = $this->usage()->byFeatureSlug($featureSlug, $this->plan_id)->first();
 
         if ($usage === null) {
             return null;
@@ -357,7 +357,7 @@ class Subscription extends Model
     public function canUseFeature(string $featureSlug): bool
     {
         $featureValue = $this->getFeatureValue($featureSlug);
-        $usage = $this->usage()->byFeatureSlug($featureSlug)->first();
+        $usage = $this->usage()->byFeatureSlug($featureSlug, $this->plan_id)->first();
 
         if ($featureValue === 'true') {
             return true;
@@ -378,7 +378,7 @@ class Subscription extends Model
      */
     public function getFeatureUsage(string $featureSlug): int
     {
-        $usage = $this->usage()->byFeatureSlug($featureSlug)->first();
+        $usage = $this->usage()->byFeatureSlug($featureSlug, $this->plan_id)->first();
 
         return (! $usage || $usage->expired()) ? 0 : $usage->used;
     }

--- a/src/Models/SubscriptionUsage.php
+++ b/src/Models/SubscriptionUsage.php
@@ -64,10 +64,10 @@ class SubscriptionUsage extends Model
         return $this->belongsTo(config('laravel-subscriptions.models.subscription'), 'subscription_id', 'id', 'subscription');
     }
 
-    public function scopeByFeatureSlug(Builder $builder, string $featureSlug): Builder
+    public function scopeByFeatureSlug(Builder $builder, string $featureSlug, int $planId): Builder
     {
         $model = config('laravel-subscriptions.models.feature', Feature::class);
-        $feature = $model::where('slug', $featureSlug)->first();
+        $feature = $model::where('plan_id', $planId)->where('slug', $featureSlug)->first();
 
         return $builder->where('feature_id', $feature ? $feature->getKey() : null);
     }


### PR DESCRIPTION
While querying the remaining rights, I saw an error about the feature with the same slug key. I solved this by adding the plan_id column to the query.