### PR TITLE
fix: scope subscription slug uniqueness per subscriber

### DIFF
--- a/src/Models/Feature.php
+++ b/src/Models/Feature.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Laravelcm\Subscriptions\Models;
 
 use Carbon\Carbon;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -20,33 +22,19 @@ use Spatie\Sluggable\SlugOptions;
 
 /**
  * @property-read int|string $id
- * @property string $slug
- * @property array $title
- * @property array $description
- * @property string $value
- * @property int $resettable_period
- * @property string $resettable_interval
- * @property int $sort_order
- * @property Carbon|null $created_at
- * @property Carbon|null $updated_at
- * @property Carbon|null $deleted_at
+ * @property-read string $slug
+ * @property-read array $title
+ * @property-read array $description
+ * @property-read string $value
+ * @property-read int|string $plan_id
+ * @property-read int $resettable_period
+ * @property-read string $resettable_interval
+ * @property-read int $sort_order
+ * @property-read CarbonInterface $created_at
+ * @property-read CarbonInterface $updated_at
+ * @property-read ?CarbonInterface $deleted_at
  * @property-read Plan $plan
- * @property-read \Illuminate\Database\Eloquent\Collection|SubscriptionUsage[] $usages
- *
- * @method static \Illuminate\Database\Eloquent\Builder|Feature byPlanId($planId)
- * @method static \Illuminate\Database\Eloquent\Builder|Feature ordered($direction = 'asc')
- * @method static \Illuminate\Database\Eloquent\Builder|Feature whereCreatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Feature whereDeletedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Feature whereDescription($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Feature whereId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Feature whereTitle($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Feature wherePlanId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Feature whereResettableInterval($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Feature whereResettablePeriod($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Feature whereSlug($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Feature whereSortOrder($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Feature whereUpdatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Feature whereValue($value)
+ * @property-read Collection<int, SubscriptionUsage> $usages
  */
 class Feature extends Model implements Sortable
 {

--- a/src/Models/Plan.php
+++ b/src/Models/Plan.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Laravelcm\Subscriptions\Models;
 
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -16,53 +18,29 @@ use Spatie\Sluggable\SlugOptions;
 
 /**
  * @property-read int|string $id
- * @property string $slug
- * @property array $name
- * @property array $description
- * @property bool $is_active
- * @property float $price
- * @property float $signup_fee
- * @property string $currency
- * @property int $trial_period
- * @property string $trial_interval
- * @property int $invoice_period
- * @property string $invoice_interval
- * @property int $grace_period
- * @property string $grace_interval
- * @property int $prorate_day
- * @property int $prorate_period
- * @property int $prorate_extend_due
- * @property int $active_subscribers_limit
- * @property int $sort_order
- * @property \Carbon\Carbon|null $created_at
- * @property \Carbon\Carbon|null $updated_at
- * @property \Carbon\Carbon|null $deleted_at
- * @property-read \Illuminate\Database\Eloquent\Collection|\Laravelcm\Subscriptions\Models\Feature[] $features
- * @property-read \Illuminate\Database\Eloquent\Collection|\Laravelcm\Subscriptions\Models\Subscription[] $subscriptions
- *
- * @method static \Illuminate\Database\Eloquent\Builder|Plan ordered($direction = 'asc')
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereActiveSubscribersLimit($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereCreatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereCurrency($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereDeletedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereDescription($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereGraceInterval($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereGracePeriod($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereInvoiceInterval($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereInvoicePeriod($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereIsActive($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereName($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan wherePrice($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereProrateDay($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereProrateExtendDue($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereProratePeriod($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereSignupFee($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereSlug($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereSortOrder($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereTrialInterval($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereTrialPeriod($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Plan whereUpdatedAt($value)
+ * @property-read string $slug
+ * @property-read array $name
+ * @property-read array $description
+ * @property-read bool $is_active
+ * @property-read float $price
+ * @property-read float $signup_fee
+ * @property-read string $currency
+ * @property-read int $trial_period
+ * @property-read string $trial_interval
+ * @property-read int $invoice_period
+ * @property-read string $invoice_interval
+ * @property-read int $grace_period
+ * @property-read string $grace_interval
+ * @property-read int $prorate_day
+ * @property-read int $prorate_period
+ * @property-read int $prorate_extend_due
+ * @property-read int $active_subscribers_limit
+ * @property-read int $sort_order
+ * @property-read CarbonInterface $created_at
+ * @property-read CarbonInterface $updated_at
+ * @property-read ?CarbonInterface $deleted_at
+ * @property-read Collection<int, Feature> $features
+ * @property-read Collection<int, Subscription> $subscriptions
  */
 class Plan extends Model implements Sortable
 {

--- a/src/Models/SubscriptionUsage.php
+++ b/src/Models/SubscriptionUsage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laravelcm\Subscriptions\Models;
 
 use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -13,23 +14,16 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * @property-read int|string $id
- * @property int $used
- * @property Carbon|null $valid_until
- * @property Carbon|null $created_at
- * @property Carbon|null $updated_at
- * @property Carbon|null $deleted_at
+ * @property-read int $feature_id
+ * @property-read int $subscription_id
+ * @property-read int $used
+ * @property-read string $timezone
+ * @property-read ?CarbonInterface $valid_until
+ * @property-read CarbonInterface $created_at
+ * @property-read CarbonInterface $updated_at
+ * @property-read ?CarbonInterface $deleted_at
  * @property-read Feature $feature
  * @property-read Subscription $subscription
- *
- * @method static \Illuminate\Database\Eloquent\Builder|SubscriptionUsage byFeatureSlug($featureSlug)
- * @method static \Illuminate\Database\Eloquent\Builder|SubscriptionUsage whereCreatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|SubscriptionUsage whereDeletedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|SubscriptionUsage whereFeatureId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|SubscriptionUsage whereId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|SubscriptionUsage whereSubscriptionId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|SubscriptionUsage whereUpdatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|SubscriptionUsage whereUsed($value)
- * @method static \Illuminate\Database\Eloquent\Builder|SubscriptionUsage whereValidUntil($value)
  */
 class SubscriptionUsage extends Model
 {
@@ -41,6 +35,7 @@ class SubscriptionUsage extends Model
         'feature_id',
         'used',
         'valid_until',
+        'timezone',
     ];
 
     protected $casts = [


### PR DESCRIPTION
Previously, subscription slugs were unique globally across all subscribers, causing slugs to increment unnecessarily (e.g., "enterprise", "enterprise-1", "enterprise-2").

Now, slug uniqueness is scoped to the subscriber (subscriber_type + subscriber_id), allowing multiple subscribers to have subscriptions  with the same slug.

## Problem

Subscription slugs were unique globally across all subscribers. When multiple subscribers subscribed to the same plan, slugs would increment unnecessarily:

| subscriber_id | slug |
|---------------|------|
| 1 | enterprise |
| 2 | enterprise-1 |
| 3 | enterprise-2 |

## Solution

Scope the slug uniqueness check to the subscriber using Spatie Sluggable's `extraScope()` method. Now each subscriber can have a subscription with the same slug:

| subscriber_id | slug |
|---------------|------|
| 1 | enterprise |
| 2 | enterprise |
| 3 | enterprise |

## Changes

- Updated `getSlugOptions()` in `Subscription` model to scope uniqueness by `subscriber_type` and `subscriber_id`