### PR TITLE
fix: use static query method in subscribedPlans instead of tap

### DIFF
--- a/src/Traits/HasPlanSubscriptions.php
+++ b/src/Traits/HasPlanSubscriptions.php
@@ -50,7 +50,9 @@ trait HasPlanSubscriptions
             ->pluck('plan_id')
             ->unique();
 
-        return tap(new (config('laravel-subscriptions.models.plan')))->whereIn('id', $planIds)->get();
+        $model = config('laravel-subscriptions.models.plan');
+
+        return $model::whereIn('id', $planIds)->get();
     }
 
     public function subscribedTo(int $planId): bool


### PR DESCRIPTION
## Summary
- Fix `subscribedPlans()` using incorrect `tap(new $model)` pattern
- Same issue as was fixed in #20 for `SubscriptionUsage::scopeByFeatureSlug`

Close #23 