### PR TITLE
feat: add Laravel 13 support

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -8,16 +8,21 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3]
-        laravel: [10.*, 11.*, 12.*]
+        php: [8.2, 8.3, 8.4]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         dependency-version: [prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*
             testbench: 9.*
           - laravel: 10.*
             testbench: 8.*
+        exclude:
+          - php: 8.2
+            laravel: 13.*
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,16 +8,21 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.3, 8.2]
-        laravel: [12.*, 11.*, 10.*]
+        php: [8.4, 8.3, 8.2]
+        laravel: [13.*, 12.*, 11.*, 10.*]
         dependency-version: [prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*
             testbench: 9.*
           - laravel: 10.*
             testbench: 8.*
+        exclude:
+          - php: 8.2
+            laravel: 13.*
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -32,11 +32,11 @@
   ],
   "require": {
     "php": "^8.2",
-    "illuminate/console": "^10.0|^11.0|^12.0",
-    "illuminate/container": "^10.0|^11.0|^12.0",
-    "illuminate/database": "^10.0|^11.0|^12.0",
-    "illuminate/support": "^10.0|^11.0|^12.0",
-    "spatie/eloquent-sortable": "^4.0.0",
+    "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/container": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+    "spatie/eloquent-sortable": "^4.0.0|^5.0",
     "spatie/laravel-package-tools": "^1.16",
     "spatie/laravel-sluggable": "^3.4.2",
     "spatie/laravel-translatable": "^6.5.0"
@@ -44,7 +44,7 @@
   "require-dev": {
     "larastan/larastan": "^2.0|^3.0",
     "laravel/pint": "^1.13",
-    "orchestra/testbench": "^8.0|^9.0|^10.0",
+    "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
     "pestphp/pest": "^2.18|^3.7",
     "spatie/test-time": "^1.3"
   },


### PR DESCRIPTION
## Summary

- Add Laravel 13 to the `illuminate/*` constraints (`^10.0|^11.0|^12.0|^13.0`)
- Bump `spatie/eloquent-sortable` to `^4.0.0|^5.0` (v5 is required for Laravel 13)
- Add `orchestra/testbench: ^11.0` to dev dependencies for Laravel 13
- Extend the CI matrix (tests + phpstan) to Laravel 13 and PHP 8.4, with `php 8.2 + laravel 13.*` excluded since Laravel 13 requires PHP 8.3+

No source code changes were needed — the existing code is already compatible. Pest test suite (11/11) and PHPStan validated locally on Laravel 13.5.0 + PHP 8.4.

Closes #44