### PR TITLE
fix: Fix method name

### DIFF
--- a/src/Models/Feature.php
+++ b/src/Models/Feature.php
@@ -89,7 +89,7 @@ class Feature extends Model implements Sortable
         parent::boot();
 
         static::deleted(function (Feature $feature): void {
-            $feature->usage()->delete();
+            $feature->usages()->delete();
         });
 
         static::creating(function (Feature $feature) {


### PR DESCRIPTION
Fix accessed method name of the usages() relation. It renamed with [034014c](https://github.com/laravelcm/laravel-subscriptions/commit/034014cefe109cb6c9a44f7668fa5a61364a81f9)