### PR TITLE
feat: add unit fields and change subscription_usage to unsigned bigint

### DIFF
--- a/database/migrations/update_features_add_meter_fields_table.php
+++ b/database/migrations/update_features_add_meter_fields_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table(config('laravel-subscriptions.tables.features'), function (Blueprint $table): void {
+            $table->string('unit')->nullable()->after('sort_order');
+            $table->string('display_unit')->nullable()->after('unit');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table(config('laravel-subscriptions.tables.features'), function (Blueprint $table): void {
+            $table->dropColumn([
+                'unit',
+                'display_unit',
+            ]);
+        });
+    }
+};

--- a/database/migrations/update_subscription_usage_change_used_to_bigint_table.php
+++ b/database/migrations/update_subscription_usage_change_used_to_bigint_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table(config('laravel-subscriptions.tables.subscription_usage'), function (Blueprint $table): void {
+            $table->unsignedBigInteger('used')->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table(config('laravel-subscriptions.tables.subscription_usage'), function (Blueprint $table): void {
+            $table->unsignedSmallInteger('used')->change();
+        });
+    }
+};

--- a/src/Models/Feature.php
+++ b/src/Models/Feature.php
@@ -26,6 +26,8 @@ use Spatie\Sluggable\SlugOptions;
  * @property-read array $title
  * @property-read array $description
  * @property-read string $value
+ * @property-read string $unit
+ * @property-read string $display_unit
  * @property-read int|string $plan_id
  * @property-read int $resettable_period
  * @property-read string $resettable_interval
@@ -51,6 +53,8 @@ class Feature extends Model implements Sortable
         'name',
         'description',
         'value',
+        'unit',
+        'display_unit',
         'resettable_period',
         'resettable_interval',
         'sort_order',
@@ -59,6 +63,8 @@ class Feature extends Model implements Sortable
     protected $casts = [
         'slug' => 'string',
         'value' => 'string',
+        'unit' => 'string',
+        'display_unit' => 'string',
         'resettable_period' => 'integer',
         'resettable_interval' => 'string',
         'sort_order' => 'integer',

--- a/src/SubscriptionServiceProvider.php
+++ b/src/SubscriptionServiceProvider.php
@@ -22,6 +22,9 @@ final class SubscriptionServiceProvider extends PackageServiceProvider
                 'remove_unique_slug_on_subscriptions_table',
                 'update_unique_keys_on_features_table',
                 'remove_cancels_at_from_subscriptions_table',
+
+                'update_features_add_meter_fields_table',
+                'update_subscription_usage_change_used_to_bigint_table',
             ])
             ->hasInstallCommand(function (InstallCommand $command): void {
                 $command


### PR DESCRIPTION
The `subscription_usage.used` field now supports larger values, allowing storage-based limits such as bytes.

New optional fields were also added:
- `unit`: stores the base unit value (e.g. `byte`)
- `display_unit`: used for UI display formatting (e.g. `TiB`)

Example:
- `1 TiB = 1099511627776 bytes`

```php
new Feature([
    'name' => 'storage',
    'value' => 1099511627776,
    'sort_order' => 1,
    'unit' => 'byte',
    'display_unit' => 'TiB',
]);